### PR TITLE
Fix README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The endpoint /api/time will return the current time in natural language format.
 The objective is not to build a robot or an IA, but by using TDD make the code reply more and more complex time combinations.
 
 Examples:
-16:20 should return "Twenty to four"
+16:20 should return "Twenty past four"
 17:00 should return "Five o'clock"
 
 But... feel free to return "Tea time", "Midnight", "Noon"...


### PR DESCRIPTION
Fix a typo where "16:20" should be "Twenty past four" instead of "Twenty to four"